### PR TITLE
hardcode weth as holding position for RYE

### DIFF
--- a/subgraphs/cellars/src/utils/constants.ts
+++ b/subgraphs/cellars/src/utils/constants.ts
@@ -1,4 +1,4 @@
-import { BigInt } from "@graphprotocol/graph-ts";
+import { Address, BigInt } from "@graphprotocol/graph-ts";
 
 export const SNAPSHOT_INTERVAL_SECS = 60 * 5; // 5 minutes
 
@@ -12,6 +12,10 @@ export const ZERO_BD = ZERO_BI.toBigDecimal();
 export const ONE_BD = ONE_BI.toBigDecimal();
 
 export const ONE_SHARE = ONE_BI.times(TEN_BI.pow(18));
+
+export const WETH_ADDRESS = Address.fromString(
+  "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+);
 
 export const CELLAR_AAVE_LATEST =
   "0x7bad5df5e11151dc5ee1a648800057c5c934c0d5".toLowerCase();

--- a/subgraphs/cellars/src/utils/v2.ts
+++ b/subgraphs/cellars/src/utils/v2.ts
@@ -10,6 +10,8 @@ import {
   ZERO_BI,
   TEN_BI,
   NEGATIVE_ONE_BI,
+  REAL_YIELD_ETH,
+  WETH_ADDRESS,
 } from "./constants";
 import {
   convertDecimals,
@@ -96,7 +98,11 @@ export function snapshotDay(
     const holdingPosition = getHoldingPosition(contract);
 
     if (holdingPosition != Address.zero()) {
-      const holdingContract = ERC20.bind(holdingPosition);
+      let holdingContract = ERC20.bind(holdingPosition);
+      if (cellarAddress == REAL_YIELD_ETH) {
+        holdingContract = ERC20.bind(WETH_ADDRESS);
+      }
+
       const holdingBalance = holdingContract.balanceOf(address);
 
       const holdingAsset = loadOrCreateTokenERC20(

--- a/subgraphs/cellars/src/utils/v2.ts
+++ b/subgraphs/cellars/src/utils/v2.ts
@@ -98,6 +98,10 @@ export function snapshotDay(
     const holdingPosition = getHoldingPosition(contract);
 
     if (holdingPosition != Address.zero()) {
+      // FIXME:
+      // remove this hack or create a mapping of cellar -> holding positions
+      // instead of getting it dynamically. Historically the holding position
+      // has never changed until we needed to block deposits to RYE.
       let holdingContract = ERC20.bind(holdingPosition);
       if (cellarAddress == REAL_YIELD_ETH) {
         holdingContract = ERC20.bind(WETH_ADDRESS);


### PR DESCRIPTION
RYE holding position was changed to the (vesting position)[https://etherscan.io/address/0xe316bc45084765d4d3f14e9771f11713b3b1c3a9] recently. This contract does not have a `balanceOf`view function so the subgraph broke. We should change this back to be dynamic or create a mapping of cellars to holding positions as per @philipjames44 suggestion.