### PR TITLE
Hourly Snapshots

### DIFF
--- a/subgraphs/cellars/schema.graphql
+++ b/subgraphs/cellars/schema.graphql
@@ -105,56 +105,6 @@ type CellarDayData @entity {
   earnings: BigInt!
 }
 
-type CellarHourDataUpdates @entity {
-  id: ID! # ??
-  date: Int! # epoch timestamp
-  cellar: Cellar!
-  asset: TokenERC20
-  updatedAt: Int!
-
-  addedLiquidity: BigInt!
-  removedLiquidity: BigInt!
-  numWallets: Int!
-
-  tvlActive: BigInt!
-  tvlInactive: BigInt!
-  tvlInvested: BigInt!
-  tvlTotal: BigInt!
-
-  shareValue: BigInt!
-  shareValueHigh: BigInt!
-  shareValueLow: BigInt!
-  shareProfitRatio: BigDecimal!
-  positionDistribution: [BigDecimal!]!
-
-  earnings: BigInt!
-}
-
-type CellarDayDataUpdates @entity {
-  id: ID! # timestamp at the start of a day Date.now / 86400
-  date: Int! # epoch timestamp
-  cellar: Cellar!
-  asset: TokenERC20!
-  updatedAt: Int!
-
-  addedLiquidity: BigInt!
-  removedLiquidity: BigInt!
-  numWallets: Int!
-
-  tvlActive: BigInt!
-  tvlInactive: BigInt!
-  tvlInvested: BigInt!
-  tvlTotal: BigInt!
-
-  shareValue: BigInt!
-  shareValueHigh: BigInt!
-  shareValueLow: BigInt!
-  shareProfitRatio: BigDecimal!
-  positionDistribution: [BigDecimal!]!
-
-  earnings: BigInt!
-}
-
 type CellarHourData @entity {
   id: ID! # ??
   date: Int! # epoch timestamp

--- a/subgraphs/cellars/schema.graphql
+++ b/subgraphs/cellars/schema.graphql
@@ -2,6 +2,7 @@ type Platform @entity {
   id: ID! # platform
 
   latestSnapshotUpdatedAt: Int!
+  latestSnapshotUpdatedAtBlock: Int!
 }
 
 # Always in USD for now
@@ -80,6 +81,56 @@ type Cellar @entity {
 }
 
 type CellarDayData @entity {
+  id: ID! # timestamp at the start of a day Date.now / 86400
+  date: Int! # epoch timestamp
+  cellar: Cellar!
+  asset: TokenERC20!
+  updatedAt: Int!
+
+  addedLiquidity: BigInt!
+  removedLiquidity: BigInt!
+  numWallets: Int!
+
+  tvlActive: BigInt!
+  tvlInactive: BigInt!
+  tvlInvested: BigInt!
+  tvlTotal: BigInt!
+
+  shareValue: BigInt!
+  shareValueHigh: BigInt!
+  shareValueLow: BigInt!
+  shareProfitRatio: BigDecimal!
+  positionDistribution: [BigDecimal!]!
+
+  earnings: BigInt!
+}
+
+type CellarHourDataUpdates @entity {
+  id: ID! # ??
+  date: Int! # epoch timestamp
+  cellar: Cellar!
+  asset: TokenERC20
+  updatedAt: Int!
+
+  addedLiquidity: BigInt!
+  removedLiquidity: BigInt!
+  numWallets: Int!
+
+  tvlActive: BigInt!
+  tvlInactive: BigInt!
+  tvlInvested: BigInt!
+  tvlTotal: BigInt!
+
+  shareValue: BigInt!
+  shareValueHigh: BigInt!
+  shareValueLow: BigInt!
+  shareProfitRatio: BigDecimal!
+  positionDistribution: [BigDecimal!]!
+
+  earnings: BigInt!
+}
+
+type CellarDayDataUpdates @entity {
   id: ID! # timestamp at the start of a day Date.now / 86400
   date: Int! # epoch timestamp
   cellar: Cellar!

--- a/subgraphs/cellars/src/snapshot-mapping.ts
+++ b/subgraphs/cellars/src/snapshot-mapping.ts
@@ -40,7 +40,7 @@ const SNAPSHOT_INTERVAL = BigInt.fromI32(10);
 const SNAPSHOT_WINDOW_SECS = 45;
 
 // Checks to see if the block timestamp is within the snapshot window
-function isWithinSnapshotWindow(block: ethereum.Block): Boolean {
+function isWithinSnapshotWindow(block: ethereum.Block): bool {
   const blockTimestamp = block.timestamp.toI32();
 
   // current hour in epoch seconds

--- a/subgraphs/cellars/src/utils/entities.ts
+++ b/subgraphs/cellars/src/utils/entities.ts
@@ -9,7 +9,8 @@ export function loadPlatform(): Platform {
   let entity = Platform.load(PLATFORM_ID);
   if (entity == null) {
     entity = new Platform(PLATFORM_ID);
-    entity.latestSnapshotUpdatedAt = 0;
+    entity.latestSnapshotUpdatedAt = ZERO_BI;
+    entity.latestSnapshotUpdatedAtBlock = ZERO_BI;
   }
 
   return entity;

--- a/subgraphs/cellars/src/utils/entities.ts
+++ b/subgraphs/cellars/src/utils/entities.ts
@@ -9,8 +9,8 @@ export function loadPlatform(): Platform {
   let entity = Platform.load(PLATFORM_ID);
   if (entity == null) {
     entity = new Platform(PLATFORM_ID);
-    entity.latestSnapshotUpdatedAt = ZERO_BI;
-    entity.latestSnapshotUpdatedAtBlock = ZERO_BI;
+    entity.latestSnapshotUpdatedAt = 0;
+    entity.latestSnapshotUpdatedAtBlock = 0;
   }
 
   return entity;

--- a/subgraphs/cellars/src/utils/v1-5.ts
+++ b/subgraphs/cellars/src/utils/v1-5.ts
@@ -43,110 +43,30 @@ export function snapshotDay(
     return;
   }
 
-  const contract = ClearGateCellar.bind(address);
-
-  // Initialize this value if not set
-  // updates will be captures by the PositionAdded and Removed events
-  if (cellar.positions.length === 0) {
-    const positions = getPositions(contract);
-    cellar.positions = positions;
-  }
-
-  cellar.positionDistribution = getPositionDistribution(
-    cellar.positions,
-    address,
-    block.number
-  );
-
   const cellarAsset = cellar.asset as string;
 
   const snapshot = loadCellarDayData(cellar.id, block.timestamp, cellarAsset);
-  snapshot.positionDistribution = cellar.positionDistribution;
 
-  const asset = loadOrCreateTokenERC20(cellarAsset);
+  // Load hour snapshot data and copy values so we don't fetch
+  // from RPC twice
+  const hour = loadCellarHourData(cellar.id, block.timestamp, cellarAsset);
+  snapshot.updatedAt = hour.updatedAt;
+  snapshot.addedLiquidity = hour.addedLiquidity;
+  snapshot.removedLiquidity = hour.removedLiquidity;
+  snapshot.numWallets = hour.numWallets;
 
-  // TODO
-  // snapshot.tvlInvested = cellar.tvlInvested
+  snapshot.tvlActive = hour.tvlActive;
+  snapshot.tvlInactive = hour.tvlInactive;
+  snapshot.tvlInvested = hour.tvlInvested;
+  snapshot.tvlTotal = hour.tvlTotal;
 
-  const convertShareResult = contract.try_convertToAssets(ONE_SHARE);
-  if (convertShareResult.reverted) {
-    log.warning("Could not call cellar.converToAssets: {}", [cellar.id]);
-  } else {
-    cellar.shareValue = convertShareResult.value;
-    snapshot.shareValue = convertShareResult.value;
+  snapshot.shareValue = hour.shareValue;
+  snapshot.shareValueHigh = hour.shareValueHigh;
+  snapshot.shareValueLow = hour.shareValueLow;
+  snapshot.shareProfitRatio = hour.shareProfitRatio;
+  snapshot.positionDistribution = hour.positionDistribution;
+  snapshot.earnings = hour.earnings;
 
-    // Set low candle
-    if (
-      snapshot.shareValueLow.equals(NEGATIVE_ONE_BI) || // default value
-      snapshot.shareValue.lt(snapshot.shareValueLow)
-    ) {
-      snapshot.shareValueLow = snapshot.shareValue;
-    }
-
-    // Set high candle
-    if (
-      snapshot.shareValueHigh.equals(NEGATIVE_ONE_BI) || // default value
-      snapshot.shareValue.gt(snapshot.shareValueHigh)
-    ) {
-      snapshot.shareValueHigh = snapshot.shareValue;
-    }
-  }
-
-  const totalAssetsResult = contract.try_totalAssets();
-  const holdingPositionResult = contract.try_holdingPosition();
-  if (totalAssetsResult.reverted) {
-    log.warning("Could not call cellar.totalAssets: {}", [cellar.id]);
-  }
-
-  if (holdingPositionResult.reverted) {
-    log.warning("Could not call cellar.holdingPosition: {}", [cellar.id]);
-  }
-
-  if (!totalAssetsResult.reverted && !holdingPositionResult.reverted) {
-    const holdingPosition = holdingPositionResult.value;
-    const holdingContract = ERC20.bind(holdingPosition);
-    const holdingBalance = holdingContract.balanceOf(address);
-
-    const holdingAsset = loadOrCreateTokenERC20(holdingPosition.toHexString());
-    const holdingDecimals = BigInt.fromI32(holdingAsset.decimals);
-    const inactiveAssets = normalizeDecimals(holdingBalance, holdingDecimals);
-
-    const totalAssets = normalizeDecimals(
-      totalAssetsResult.value,
-      BigInt.fromI32(asset.decimals)
-    );
-
-    const singleShare = convertDecimals(ONE_BI, ZERO_BI, holdingDecimals);
-    const shareProfitRatio = cellar.shareValue
-      .minus(singleShare)
-      .toBigDecimal()
-      .div(singleShare.toBigDecimal());
-    snapshot.shareProfitRatio = shareProfitRatio;
-    snapshot.tvlInactive = inactiveAssets;
-    snapshot.tvlTotal = totalAssets;
-    snapshot.tvlActive = snapshot.tvlTotal.minus(inactiveAssets);
-
-    cellar.shareProfitRatio = shareProfitRatio;
-    cellar.tvlInactive = snapshot.tvlInactive;
-    cellar.tvlTotal = snapshot.tvlTotal;
-    cellar.tvlActive = snapshot.tvlActive;
-    cellar.save();
-
-    const prevSnap = loadPrevCellarDayData(
-      cellar.id,
-      block.timestamp,
-      cellarAsset
-    );
-
-    // totalAssets[now] + withdrawnAssets[now] - totalAssets[yesterday] + withdrawnAssets[yesterday] - addedLiquidity[now]
-    snapshot.earnings = snapshot.tvlTotal
-      .minus(prevSnap.tvlTotal)
-      .plus(prevSnap.removedLiquidity)
-      .plus(snapshot.removedLiquidity)
-      .minus(snapshot.addedLiquidity);
-  }
-
-  snapshot.updatedAt = block.timestamp.toI32();
   snapshot.save();
 }
 
@@ -169,6 +89,19 @@ export function snapshotHour(
 
   const contract = ClearGateCellar.bind(address);
   const cellarAsset = cellar.asset as string;
+
+  // Initialize this value if not set
+  // updates will be captures by the PositionAdded and Removed events
+  if (cellar.positions.length === 0) {
+    const positions = getPositions(contract);
+    cellar.positions = positions;
+  }
+
+  cellar.positionDistribution = getPositionDistribution(
+    cellar.positions,
+    address,
+    block.number
+  );
 
   const snapshot = loadCellarHourData(cellar.id, block.timestamp, cellarAsset);
   snapshot.positionDistribution = cellar.positionDistribution;


### PR DESCRIPTION
- Reduces churn on the day data table by only snapshotting hourly instead of every block. We should see a reduction in rows on that table by almost 275x.
- Reduces number of rpc calls made by half